### PR TITLE
Update DockerAPI.java

### DIFF
--- a/docker/src/main/java/edu/kit/kastel/informalin/framework/docker/DockerAPI.java
+++ b/docker/src/main/java/edu/kit/kastel/informalin/framework/docker/DockerAPI.java
@@ -85,7 +85,7 @@ public final class DockerAPI {
         try {
             var configInformationNode = oom.readTree(result.stdOut()).get(0);
             var repoTags = configInformationNode.get("RepoTags").get(0).asText().split(":");
-            var containerConfig = configInformationNode.get("ContainerConfig");
+            var containerConfig = configInformationNode.get("Config");
             if (!containerConfig.hasNonNull("ExposedPorts")) {
                 return new DockerImage(repoTags[0], repoTags[1], List.of());
             }


### PR DESCRIPTION
I suggest loading the exposed port from the Config node instead of ContainerConfig. When I build an image from a Dockerfile that specifies an exposed port, the ExposedPort field does not appear under ContainerConfig but only under Config.