### PR TITLE
Feature/lock pipeline run

### DIFF
--- a/configuration/src/main/java/edu/kit/kastel/informalin/framework/configuration/AbstractConfigurable.java
+++ b/configuration/src/main/java/edu/kit/kastel/informalin/framework/configuration/AbstractConfigurable.java
@@ -1,23 +1,25 @@
 /* Licensed under MIT 2022. */
 package edu.kit.kastel.informalin.framework.configuration;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public abstract class AbstractConfigurable implements IConfigurable {
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
     public static final String CLASS_ATTRIBUTE_CONNECTOR = "::";
     public static final String KEY_VALUE_CONNECTOR = "=";
-
     public static final String LIST_SEPARATOR = ",";
 
-    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private Map<String, String> lastAppliedConfiguration = new HashMap<>();
 
     protected final <E> List<E> findByClassName(List<String> selected, List<E> instances) {
         List<E> target = new ArrayList<>(0);
@@ -35,6 +37,12 @@ public abstract class AbstractConfigurable implements IConfigurable {
     public final void applyConfiguration(Map<String, String> additionalConfiguration) {
         applyConfiguration(additionalConfiguration, this.getClass());
         delegateApplyConfigurationToInternalObjects(additionalConfiguration);
+        this.lastAppliedConfiguration = additionalConfiguration;
+    }
+
+    @Override
+    public Map<String, String> getLastAppliedConfiguration() {
+        return lastAppliedConfiguration;
     }
 
     protected abstract void delegateApplyConfigurationToInternalObjects(Map<String, String> additionalConfiguration);
@@ -87,7 +95,7 @@ public abstract class AbstractConfigurable implements IConfigurable {
             return result.orElseThrow(() -> new IllegalArgumentException("Unknown Enum Constant " + value));
         }
 
-        if (List.class.isAssignableFrom(fieldsClass) && field.getGenericType()instanceof ParameterizedType parameterizedType) {
+        if (List.class.isAssignableFrom(fieldsClass) && field.getGenericType() instanceof ParameterizedType parameterizedType) {
             var generics = parameterizedType.getActualTypeArguments();
 
             if (generics != null && generics.length == 1 && generics[0] == String.class)

--- a/configuration/src/main/java/edu/kit/kastel/informalin/framework/configuration/AbstractConfigurable.java
+++ b/configuration/src/main/java/edu/kit/kastel/informalin/framework/configuration/AbstractConfigurable.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,12 +38,12 @@ public abstract class AbstractConfigurable implements IConfigurable {
     public final void applyConfiguration(Map<String, String> additionalConfiguration) {
         applyConfiguration(additionalConfiguration, this.getClass());
         delegateApplyConfigurationToInternalObjects(additionalConfiguration);
-        this.lastAppliedConfiguration = additionalConfiguration;
+        this.lastAppliedConfiguration = new HashMap<>(additionalConfiguration);
     }
 
     @Override
     public Map<String, String> getLastAppliedConfiguration() {
-        return lastAppliedConfiguration;
+        return Collections.unmodifiableMap(lastAppliedConfiguration);
     }
 
     protected abstract void delegateApplyConfigurationToInternalObjects(Map<String, String> additionalConfiguration);

--- a/configuration/src/main/java/edu/kit/kastel/informalin/framework/configuration/IConfigurable.java
+++ b/configuration/src/main/java/edu/kit/kastel/informalin/framework/configuration/IConfigurable.java
@@ -5,4 +5,6 @@ import java.util.Map;
 
 public interface IConfigurable {
     void applyConfiguration(Map<String, String> additionalConfiguration);
+
+    Map<String, String> getLastAppliedConfiguration();
 }

--- a/pipeline/src/main/java/edu/kit/kastel/informalin/pipeline/Pipeline.java
+++ b/pipeline/src/main/java/edu/kit/kastel/informalin/pipeline/Pipeline.java
@@ -19,7 +19,7 @@ public class Pipeline extends AbstractPipelineStep {
 
     /**
      * Constructs a Pipeline with the given id and {@link DataRepository}.
-     * 
+     *
      * @param id             id for the pipeline
      * @param dataRepository {@link DataRepository} that should be used for fetching and saving data
      */
@@ -30,7 +30,7 @@ public class Pipeline extends AbstractPipelineStep {
 
     /**
      * Constructs a Pipeline with the given id and {@link DataRepository}.
-     * 
+     *
      * @param id             id for the pipeline
      * @param dataRepository {@link DataRepository} that should be used for fetching and saving data
      * @param pipelineSteps  List of {@link AbstractPipelineStep} that should be added to the constructed pipeline
@@ -42,7 +42,7 @@ public class Pipeline extends AbstractPipelineStep {
 
     /**
      * Adds a {@link AbstractPipelineStep} to the execution list of this pipeline
-     * 
+     *
      * @param pipelineStep step that should be added
      * @return True, if the step was added successfully. Otherwise, returns false
      */
@@ -51,7 +51,8 @@ public class Pipeline extends AbstractPipelineStep {
     }
 
     @Override
-    public void run() {
+    public final void run() {
+        preparePipelineSteps();
         for (var pipelineStep : this.pipelineSteps) {
             logger.info("Starting {} - {}", this.getId(), pipelineStep.getId());
             var start = Instant.now();
@@ -65,6 +66,17 @@ public class Pipeline extends AbstractPipelineStep {
                 logger.info("Finished {} - {} in {}", this.getId(), pipelineStep.getId(), durationString);
             }
         }
+    }
+
+    /**
+     * This method is called at the start of running the pipeline. Within this method, the added PipelineSteps are prepared.
+     * Sub-classes of Pipeline can override it with special cases.
+     * It is recommended that you apply the Map from {@link #getLastAppliedConfiguration()} via {@link #applyConfiguration(Map)} to each pipeline step.
+     * You can do that on your own if you need special treatment or by default call {@link #delegateApplyConfigurationToInternalObjects(Map)}.
+     * The base version does apply the last configuration via the default call.
+     */
+    protected void preparePipelineSteps() {
+        delegateApplyConfigurationToInternalObjects(getLastAppliedConfiguration());
     }
 
     @Override


### PR DESCRIPTION
With this PR, we update the definition of Pipeline. 
We lock the `run()` method in `Pipeline`by finalizing the method. This makes it impossible to override it in sub-classes and ensures that the code in `Pipeline`'s `run()` is always executed.
If you need to execute code prior to executing the registered pipeline steps, there is the `preparePipelineSteps()` method that is executed at the start of the `run()` method.

IMPORTANT: This is a breaking change!