### PR TITLE
Improve handling of FileInputStreams via try-with-resources

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -45,4 +45,4 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Test with Maven
-        run: mvn -B verify --file pom.xml
+        run: mvn -U -B verify

--- a/models/src/main/java/edu/kit/kastel/informalin/framework/models/pcm/PCMModel.java
+++ b/models/src/main/java/edu/kit/kastel/informalin/framework/models/pcm/PCMModel.java
@@ -2,32 +2,40 @@
 package edu.kit.kastel.informalin.framework.models.pcm;
 
 import org.fuchss.xmlobjectmapper.XML2Object;
+import org.fuchss.xmlobjectmapper.XMLException;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 public class PCMModel {
     private PCMRepository repository;
 
-    public PCMModel(File repository) throws IOException {
-        this(new FileInputStream(repository));
-    }
-
-    public PCMModel(InputStream repositoryStream) {
-        try {
-            this.load(repositoryStream);
-        } catch (ReflectiveOperationException | IOException e) {
+    public PCMModel(File repository) throws IllegalArgumentException {
+        try (var inputStream = new FileInputStream(repository)) {
+            this.load(inputStream);
+        } catch (IOException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
+    }
+
+    public PCMModel(InputStream repositoryStream) throws IllegalArgumentException {
+        this.load(repositoryStream);
     }
 
     public PCMRepository getRepository() {
         return repository;
     }
 
-    private void load(InputStream repositoryStream) throws ReflectiveOperationException, IOException {
-        XML2Object xml2Object = new XML2Object();
-        xml2Object.registerClasses(PCMRepository.class, PCMComponent.class, PCMInterface.class, PCMSignature.class, PCMComponent.InterfaceId.class);
-        repository = xml2Object.parseXML(repositoryStream, PCMRepository.class);
-        repository.init();
+    private void load(InputStream repositoryStream) throws IllegalArgumentException {
+        try (repositoryStream) {
+            XML2Object xml2Object = new XML2Object();
+            xml2Object.registerClasses(PCMRepository.class, PCMComponent.class, PCMInterface.class, PCMSignature.class, PCMComponent.InterfaceId.class);
+            repository = xml2Object.parseXML(repositoryStream, PCMRepository.class);
+            repository.init();
+        } catch (ReflectiveOperationException | IOException | XMLException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
     }
 }

--- a/models/src/main/java/edu/kit/kastel/informalin/framework/models/uml/UMLModel.java
+++ b/models/src/main/java/edu/kit/kastel/informalin/framework/models/uml/UMLModel.java
@@ -1,37 +1,45 @@
 /* Licensed under MIT 2022. */
 package edu.kit.kastel.informalin.framework.models.uml;
 
-import java.io.*;
-
-import org.fuchss.xmlobjectmapper.XML2Object;
-
 import edu.kit.kastel.informalin.framework.models.uml.xml_elements.OwnedOperation;
 import edu.kit.kastel.informalin.framework.models.uml.xml_elements.PackagedElement;
 import edu.kit.kastel.informalin.framework.models.uml.xml_elements.Reference;
+import org.fuchss.xmlobjectmapper.XML2Object;
+import org.fuchss.xmlobjectmapper.XMLException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 
 public class UMLModel {
     private UMLModelRoot model;
 
     public UMLModel(File umlModel) throws IOException {
-        this(new FileInputStream(umlModel));
-    }
-
-    public UMLModel(InputStream umlModelStream) {
-        try {
-            this.load(umlModelStream);
-        } catch (ReflectiveOperationException | IOException e) {
+        try (var inputStream = new FileInputStream(umlModel)) {
+            this.load(inputStream);
+        } catch (FileNotFoundException e) {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
+    }
+
+    public UMLModel(InputStream umlModelStream) throws IllegalArgumentException {
+        this.load(umlModelStream);
     }
 
     public UMLModelRoot getModel() {
         return model;
     }
 
-    private void load(InputStream repositoryStream) throws ReflectiveOperationException, IOException {
-        XML2Object xml2Object = new XML2Object();
-        xml2Object.registerClasses(UMLModelRoot.class, PackagedElement.class, OwnedOperation.class, Reference.class);
-        model = xml2Object.parseXML(repositoryStream, UMLModelRoot.class);
-        model.init();
+    private void load(InputStream repositoryStream) throws IllegalArgumentException {
+        try (repositoryStream) {
+            XML2Object xml2Object = new XML2Object();
+            xml2Object.registerClasses(UMLModelRoot.class, PackagedElement.class, OwnedOperation.class, Reference.class);
+            model = xml2Object.parseXML(repositoryStream, UMLModelRoot.class);
+            model.init();
+        } catch (ReflectiveOperationException | IOException | XMLException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
     }
 }

--- a/models/src/test/java/edu/kit/kastel/informalin/framework/models/pcm/PCMModelTest.java
+++ b/models/src/test/java/edu/kit/kastel/informalin/framework/models/pcm/PCMModelTest.java
@@ -1,11 +1,12 @@
 /* Licensed under MIT 2022. */
 package edu.kit.kastel.informalin.framework.models.pcm;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.io.IOException;
 
 class PCMModelTest {
     private static final String PATH_TO_MODEL = "src/test/resources/benchmark/mediastore/pcm/ms.repository";
@@ -17,6 +18,18 @@ class PCMModelTest {
         var repo = pcmModel.getRepository();
         for (var component : repo.getComponents()) {
             Assertions.assertFalse(component.getProvided().isEmpty(), "Component " + component.getEntityName() + " has no provided interface");
+        }
+    }
+
+    @Test
+    void simpleLoadViaProvidedStream() throws IOException {
+        try (FileInputStream fis = new FileInputStream(PATH_TO_MODEL)) {
+            PCMModel pcmModel = new PCMModel(fis);
+            Assertions.assertNotNull(pcmModel.getRepository());
+            var repo = pcmModel.getRepository();
+            for (var component : repo.getComponents()) {
+                Assertions.assertFalse(component.getProvided().isEmpty(), "Component " + component.getEntityName() + " has no provided interface");
+            }
         }
     }
 }


### PR DESCRIPTION
The constructors of PCMModel and UMLModel open FileInputStreams without closing them properly or handling them in any way. This PR fixes it by using try-with-resources for these occasions.